### PR TITLE
Add R4JCircuitBreakerCustomizer interface

### DIFF
--- a/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JAutoConfiguration.java
@@ -17,8 +17,11 @@ package org.springframework.cloud.circuitbreaker.r4j;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreakerFactory;
@@ -53,16 +56,18 @@ public class R4JAutoConfiguration {
 	@ConditionalOnMissingBean(CircuitBreakerFactory.class)
 	public CircuitBreakerFactory r4jCircuitBreakerFactory(R4JConfigFactory r4JConfigFactory,
 														  CircuitBreakerRegistry circuitBreakerRegistry,
-														  ExecutorService executorService) {
-		return new R4JCircuitBreakerFactory(r4JConfigFactory, circuitBreakerRegistry, executorService);
+														  ExecutorService executorService,
+														  Optional<R4JCircuitBreakerCustomizer> customizer) {
+		return new R4JCircuitBreakerFactory(r4JConfigFactory, circuitBreakerRegistry, customizer.orElse(R4JCircuitBreakerCustomizer.NO_OP), executorService);
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
 	@ConditionalOnClass(name = {"reactor.core.publisher.Mono", "reactor.core.publisher.Flux"})
 	public ReactiveCircuitBreakerFactory reactiveR4JCircuitBreakerFactory(R4JConfigFactory r4JConfigFactory,
-																		  CircuitBreakerRegistry circuitBreakerRegistry) {
-		return new ReactiveR4JCircuitBreakerFactory(r4JConfigFactory, circuitBreakerRegistry);
+																		  CircuitBreakerRegistry circuitBreakerRegistry,
+																		  Optional<R4JCircuitBreakerCustomizer> customizer) {
+		return new ReactiveR4JCircuitBreakerFactory(r4JConfigFactory, circuitBreakerRegistry, customizer.orElse(R4JCircuitBreakerCustomizer.NO_OP));
 	}
 
 }

--- a/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreaker.java
@@ -16,17 +16,18 @@
 
 package org.springframework.cloud.circuitbreaker.r4j;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.timelimiter.TimeLimiter;
-import io.github.resilience4j.timelimiter.TimeLimiterConfig;
-import io.vavr.control.Try;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreaker;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.timelimiter.TimeLimiter;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import io.vavr.control.Try;
 
 
 /**
@@ -38,15 +39,20 @@ public class R4JCircuitBreaker implements CircuitBreaker {
 	private io.github.resilience4j.circuitbreaker.CircuitBreakerConfig circuitBreakerConfig;
 	private CircuitBreakerRegistry registry;
 	private TimeLimiterConfig timeLimiterConfig;
+	private R4JCircuitBreakerCustomizer r4JCircuitBreakerCustomizer;
 	private ExecutorService executorService;
 
-	public R4JCircuitBreaker(String id, io.github.resilience4j.circuitbreaker.CircuitBreakerConfig circuitBreakerConfig,
-							 TimeLimiterConfig timeLimiterConfig, CircuitBreakerRegistry circuitBreakerRegistry,
-							 ExecutorService executorService) {
+	public R4JCircuitBreaker(String id,
+			io.github.resilience4j.circuitbreaker.CircuitBreakerConfig circuitBreakerConfig,
+			TimeLimiterConfig timeLimiterConfig,
+			CircuitBreakerRegistry circuitBreakerRegistry,
+			R4JCircuitBreakerCustomizer r4JCircuitBreakerCustomizer,
+			ExecutorService executorService) {
 		this.id = id;
 		this.circuitBreakerConfig = circuitBreakerConfig;
 		this.registry = circuitBreakerRegistry;
 		this.timeLimiterConfig = timeLimiterConfig;
+		this.r4JCircuitBreakerCustomizer = r4JCircuitBreakerCustomizer;
 		this.executorService = executorService;
 	}
 
@@ -58,6 +64,7 @@ public class R4JCircuitBreaker implements CircuitBreaker {
 				.decorateFutureSupplier(timeLimiter, futureSupplier);
 
 		io.github.resilience4j.circuitbreaker.CircuitBreaker defaultCircuitBreaker = registry.circuitBreaker(id, circuitBreakerConfig);
+		r4JCircuitBreakerCustomizer.customize(defaultCircuitBreaker);
 		Callable<T> callable = io.github.resilience4j.circuitbreaker.CircuitBreaker
 				.decorateCallable(defaultCircuitBreaker, restrictedCall);
 		return Try.of(callable::call).get();
@@ -71,6 +78,7 @@ public class R4JCircuitBreaker implements CircuitBreaker {
 				.decorateFutureSupplier(timeLimiter, futureSupplier);
 
 		io.github.resilience4j.circuitbreaker.CircuitBreaker defaultCircuitBreaker = registry.circuitBreaker(id, circuitBreakerConfig);
+		r4JCircuitBreakerCustomizer.customize(defaultCircuitBreaker);
 		Callable<T> callable = io.github.resilience4j.circuitbreaker.CircuitBreaker
 				.decorateCallable(defaultCircuitBreaker, restrictedCall);
 		return Try.of(callable::call).recover(fallback).get();

--- a/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreakerCustomizer.java
+++ b/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreakerCustomizer.java
@@ -1,0 +1,25 @@
+package org.springframework.cloud.circuitbreaker.r4j;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+
+/**
+ * Callback interface that can be used to customize a R4j {@link CircuitBreaker}.
+ *
+ * @author Toshiaki Maki
+ */
+@FunctionalInterface
+public interface R4JCircuitBreakerCustomizer {
+
+	/**
+	 * Customize the circuitBreaker.
+	 *
+	 * @param circuitBreaker the circuit breaker to customize
+	 */
+	void customize(CircuitBreaker circuitBreaker);
+
+	/**
+	 * Default customize that does nothing.
+	 */
+	R4JCircuitBreakerCustomizer NO_OP = circuitBreaker -> {
+	};
+}

--- a/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreakerFactory.java
@@ -16,11 +16,12 @@
 
 package org.springframework.cloud.circuitbreaker.r4j;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-
 import java.util.concurrent.ExecutorService;
+
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreaker;
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreakerFactory;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
 /**
  * @author Ryan Baxter
@@ -30,18 +31,23 @@ public class R4JCircuitBreakerFactory implements CircuitBreakerFactory {
 	private String id;
 	private R4JConfigFactory r4JConfigFactory;
 	private CircuitBreakerRegistry circuitBreakerRegistry;
+	private R4JCircuitBreakerCustomizer r4JCircuitBreakerCustomizer;
 	private ExecutorService executorService;
 
-	public R4JCircuitBreakerFactory(R4JConfigFactory r4JConfigFactory, CircuitBreakerRegistry circuitBreakerRegistry,
-									ExecutorService executorService) {
+	public R4JCircuitBreakerFactory(R4JConfigFactory r4JConfigFactory,
+			CircuitBreakerRegistry circuitBreakerRegistry,
+			R4JCircuitBreakerCustomizer r4JCircuitBreakerCustomizer,
+			ExecutorService executorService) {
 		this.r4JConfigFactory = r4JConfigFactory;
 		this.circuitBreakerRegistry = circuitBreakerRegistry;
+		this.r4JCircuitBreakerCustomizer = r4JCircuitBreakerCustomizer;
 		this.executorService = executorService;
 	}
 
 	@Override
 	public CircuitBreaker create(String id) {
-		return new R4JCircuitBreaker(id, r4JConfigFactory.getCircuitBreakerConfig(id), r4JConfigFactory.getTimeLimiterConfig(id),
-				circuitBreakerRegistry, executorService);
+		return new R4JCircuitBreaker(id, r4JConfigFactory.getCircuitBreakerConfig(id),
+				r4JConfigFactory.getTimeLimiterConfig(id), circuitBreakerRegistry,
+				r4JCircuitBreakerCustomizer, executorService);
 	}
 }

--- a/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/ReactiveR4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/ReactiveR4JCircuitBreakerFactory.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.cloud.circuitbreaker.r4j;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 
 /**
  * @author Ryan Baxter
@@ -27,15 +27,19 @@ public class ReactiveR4JCircuitBreakerFactory implements ReactiveCircuitBreakerF
 
 	private R4JConfigFactory r4JConfigFactory;
 	private CircuitBreakerRegistry circuitBreakerRegistry;
+	private R4JCircuitBreakerCustomizer r4JCircuitBreakerCustomizer;
 
-	public ReactiveR4JCircuitBreakerFactory(R4JConfigFactory r4JConfigFactory, CircuitBreakerRegistry circuitBreakerRegistry) {
+	public ReactiveR4JCircuitBreakerFactory(R4JConfigFactory r4JConfigFactory,
+			CircuitBreakerRegistry circuitBreakerRegistry,
+			R4JCircuitBreakerCustomizer r4JCircuitBreakerCustomizer) {
 		this.r4JConfigFactory = r4JConfigFactory;
 		this.circuitBreakerRegistry = circuitBreakerRegistry;
+		this.r4JCircuitBreakerCustomizer = r4JCircuitBreakerCustomizer;
 	}
 
 	@Override
 	public ReactiveCircuitBreaker create(String id) {
 		return new ReactiveR4JCircuitBreaker(id, r4JConfigFactory.getCircuitBreakerConfig(id), r4JConfigFactory.getTimeLimiterConfig(id),
-				circuitBreakerRegistry);
+				circuitBreakerRegistry, r4JCircuitBreakerCustomizer);
 	}
 }

--- a/spring-cloud-circuitbreaker-r4j/src/test/java/org/springframework/cloud/circuitbreaker/r4j/ReactiveR4JCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-r4j/src/test/java/org/springframework/cloud/circuitbreaker/r4j/ReactiveR4JCircuitBreakerTest.java
@@ -15,16 +15,18 @@
  */
 package org.springframework.cloud.circuitbreaker.r4j;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.junit.Test;
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * @author Ryan Baxter
@@ -33,30 +35,67 @@ public class ReactiveR4JCircuitBreakerTest {
 
 	@Test
 	public void runMono() {
-		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(new R4JConfigFactory.DefaultR4JConfigFactory(),
-				CircuitBreakerRegistry.ofDefaults()).create("foo");
+		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(
+				new R4JConfigFactory.DefaultR4JConfigFactory(),
+				CircuitBreakerRegistry.ofDefaults(), R4JCircuitBreakerCustomizer.NO_OP)
+						.create("foo");
 		assertEquals("foobar", cb.run(Mono.just("foobar")).block());
 	}
 
 	@Test
 	public void runMonoWithFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(new R4JConfigFactory.DefaultR4JConfigFactory(),
-				CircuitBreakerRegistry.ofDefaults()).create("foo");
-		assertEquals("fallback", cb.run(Mono.error(new RuntimeException("boom")), t -> Mono.just("fallback")).block());
+		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(
+				new R4JConfigFactory.DefaultR4JConfigFactory(),
+				CircuitBreakerRegistry.ofDefaults(), R4JCircuitBreakerCustomizer.NO_OP)
+						.create("foo");
+		assertEquals("fallback", cb
+				.run(Mono.error(new RuntimeException("boom")), t -> Mono.just("fallback"))
+				.block());
+	}
+
+	@Test
+	public void customizeEventPublisherMono() {
+		AtomicBoolean isCalled = new AtomicBoolean(false);
+		R4JCircuitBreakerCustomizer customizer = circuitBreaker -> circuitBreaker
+				.getEventPublisher().onSuccess(event -> isCalled.set(true));
+		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(
+				new R4JConfigFactory.DefaultR4JConfigFactory(),
+				CircuitBreakerRegistry.ofDefaults(), customizer).create("foo");
+		assertEquals("foobar", cb.run(Mono.just("foobar")).block());
+		assertTrue(isCalled.get());
 	}
 
 	@Test
 	public void runFlux() {
-		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(new R4JConfigFactory.DefaultR4JConfigFactory(),
-				CircuitBreakerRegistry.ofDefaults()).create("foo");
-		assertEquals(Arrays.asList("foobar", "hello world"), cb.run(Flux.just("foobar", "hello world")).collectList().block());
+		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(
+				new R4JConfigFactory.DefaultR4JConfigFactory(),
+				CircuitBreakerRegistry.ofDefaults(), R4JCircuitBreakerCustomizer.NO_OP)
+						.create("foo");
+		assertEquals(Arrays.asList("foobar", "hello world"),
+				cb.run(Flux.just("foobar", "hello world")).collectList().block());
 	}
 
 	@Test
 	public void runFluxWithFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(new R4JConfigFactory.DefaultR4JConfigFactory(),
-				CircuitBreakerRegistry.ofDefaults()).create("foo");
-		assertEquals(Arrays.asList("fallback"), cb.run(Flux.error(new RuntimeException("boom")), t -> Flux.just("fallback")).collectList().block());
+		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(
+				new R4JConfigFactory.DefaultR4JConfigFactory(),
+				CircuitBreakerRegistry.ofDefaults(), R4JCircuitBreakerCustomizer.NO_OP)
+						.create("foo");
+		assertEquals(Arrays.asList("fallback"), cb
+				.run(Flux.error(new RuntimeException("boom")), t -> Flux.just("fallback"))
+				.collectList().block());
 	}
 
+	@Test
+	public void customizeEventPublisherFlux() {
+		AtomicBoolean isCalled = new AtomicBoolean(false);
+		R4JCircuitBreakerCustomizer customizer = circuitBreaker -> circuitBreaker
+				.getEventPublisher().onSuccess(event -> isCalled.set(true));
+		ReactiveCircuitBreaker cb = new ReactiveR4JCircuitBreakerFactory(
+				new R4JConfigFactory.DefaultR4JConfigFactory(),
+				CircuitBreakerRegistry.ofDefaults(), customizer).create("foo");
+		assertEquals(Arrays.asList("foobar", "hello world"),
+				cb.run(Flux.just("foobar", "hello world")).collectList().block());
+		assertTrue(isCalled.get());
+	}
 }


### PR DESCRIPTION
This commit adds `R4JCircuitBreakerCustomizer` interface.
so that a R4J's `CircuitBreaker` instance can be configured after created.
This can be used to [consume events](https://resilience4j.github.io/resilience4j/#_consume_emitted_circuitbreakerevents) or [monitor metrics](https://resilience4j.github.io/resilience4j/#_monitoring).