### PR TITLE
Use concrete Factory class for customizers

### DIFF
--- a/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerAutoConfiguration.java
@@ -39,7 +39,7 @@ public class HystrixCircuitBreakerAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CircuitBreakerFactory.class)
-	public CircuitBreakerFactory hystrixCircuitBreakerFactory() {
+	public HystrixCircuitBreakerFactory hystrixCircuitBreakerFactory() {
 		return new HystrixCircuitBreakerFactory();
 	}
 
@@ -54,10 +54,10 @@ public class HystrixCircuitBreakerAutoConfiguration {
 	protected static class HystrixCircuitBreakerCustomizerConfiguration {
 
 		@Autowired(required = false)
-		private List<Customizer<CircuitBreakerFactory>> customizers = new ArrayList<>();
+		private List<Customizer<HystrixCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired
-		private CircuitBreakerFactory factory;
+		private HystrixCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {
@@ -69,10 +69,10 @@ public class HystrixCircuitBreakerAutoConfiguration {
 	protected static class ReactiveHystrixCircuitBreakerCustomizerConfiguration {
 
 		@Autowired(required = false)
-		private List<Customizer<ReactiveCircuitBreakerFactory>> customizers = new ArrayList<>();
+		private List<Customizer<ReactiveHystrixCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired
-		private ReactiveCircuitBreakerFactory factory;
+		private ReactiveHystrixCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {

--- a/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerIntegrationTest.java
@@ -53,12 +53,13 @@ public class HystrixCircuitBreakerIntegrationTest {
 	protected static class Application {
 		@RequestMapping("/slow")
 		public String slow() throws InterruptedException {
-			Thread.sleep(3000);
+			Thread.sleep(2000);
 			return "slow";
 		}
 
 		@GetMapping("/normal")
-		public String normal() {
+		public String normal() throws InterruptedException  {
+			Thread.sleep(1000);
 			return "normal";
 		}
 

--- a/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/ReactiveHystrixCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/ReactiveHystrixCircuitBreakerIntegrationTest.java
@@ -63,25 +63,23 @@ public class ReactiveHystrixCircuitBreakerIntegrationTest {
 
 		@RequestMapping("/slow")
 		public Mono<String> slow() {
-			return Mono.just("slow").delayElement(Duration.ofSeconds(3));
+			return Mono.just("slow").delayElement(Duration.ofSeconds(2));
 		}
 
 		@GetMapping("/normal")
 		public Mono<String> normal() {
-			return Mono.just("normal");
+			return Mono.just("normal").delayElement(Duration.ofSeconds(1));
 		}
 
 		@Bean
-		public Customizer<ReactiveCircuitBreakerFactory<HystrixObservableCommand.Setter,
-				ReactiveHystrixCircuitBreakerFactory.ReactiveHystrixConfigBuilder>> customizer() {
+		public Customizer<ReactiveHystrixCircuitBreakerFactory> customizer() {
 			return factory -> factory.configure("slow",
 					builder -> builder.commandProperties(
 							HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(2000)));
 		}
 
 		@Bean
-		public Customizer<ReactiveCircuitBreakerFactory<HystrixObservableCommand.Setter,
-				ReactiveHystrixCircuitBreakerFactory.ReactiveHystrixConfigBuilder>> defaultConfig() {
+		public Customizer<ReactiveHystrixCircuitBreakerFactory> defaultConfig() {
 			return factory -> factory.configureDefault(id -> {
 				return HystrixObservableCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(id))
 						.andCommandPropertiesDefaults(HystrixCommandProperties.Setter()

--- a/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-r4j/src/main/java/org/springframework/cloud/circuitbreaker/r4j/R4JAutoConfiguration.java
@@ -17,7 +17,9 @@ package org.springframework.cloud.circuitbreaker.r4j;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.annotation.PostConstruct;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -35,24 +37,24 @@ public class R4JAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(CircuitBreakerFactory.class)
-	public CircuitBreakerFactory r4jCircuitBreakerFactory() {
+	public R4JCircuitBreakerFactory r4jCircuitBreakerFactory() {
 		return new R4JCircuitBreakerFactory();
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
 	@ConditionalOnClass(name = {"reactor.core.publisher.Mono", "reactor.core.publisher.Flux"})
-	public ReactiveCircuitBreakerFactory reactiveR4JCircuitBreakerFactory() {
+	public ReactiveR4JCircuitBreakerFactory reactiveR4JCircuitBreakerFactory() {
 		return new ReactiveR4JCircuitBreakerFactory();
 	}
 
 	@Configuration
 	public static class R4JCustomizerConfiguration {
 		@Autowired(required = false)
-		public List<Customizer<CircuitBreakerFactory>> customizers = new ArrayList<>();
+		public List<Customizer<R4JCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired
-		public CircuitBreakerFactory factory;
+		public R4JCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {
@@ -63,10 +65,10 @@ public class R4JAutoConfiguration {
 	@Configuration
 	public static class ReactiveR4JCustomizerConfiguration {
 		@Autowired(required = false)
-		public List<Customizer<ReactiveCircuitBreakerFactory>> customizers = new ArrayList<>();
+		public List<Customizer<ReactiveR4JCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired
-		public ReactiveCircuitBreakerFactory factory;
+		public ReactiveR4JCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {

--- a/spring-cloud-circuitbreaker-r4j/src/test/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-r4j/src/test/java/org/springframework/cloud/circuitbreaker/r4j/R4JCircuitBreakerIntegrationTest.java
@@ -53,23 +53,24 @@ public class R4JCircuitBreakerIntegrationTest {
 	protected static class Application {
 		@GetMapping("/slow")
 		public String slow() throws InterruptedException {
-			Thread.sleep(3000);
+			Thread.sleep(2000);
 			return "slow";
 		}
 
 		@GetMapping("/normal")
-		public String normal() {
+		public String normal() throws InterruptedException  {
+			Thread.sleep(1000);
 			return "normal";
 		}
 
 		@Bean
-		public Customizer<CircuitBreakerFactory<R4JConfigBuilder.R4JCircuitBreakerConfiguration, R4JConfigBuilder>> slowCustomizer() {
+		public Customizer<R4JCircuitBreakerFactory> slowCustomizer() {
 			return factory -> factory.configure("slow", builder -> builder.circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())
 					.timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(2)).build()));
 		}
 
 		@Bean
-		public Customizer<CircuitBreakerFactory<R4JConfigBuilder.R4JCircuitBreakerConfiguration, R4JConfigBuilder>> defaultCustomizer() {
+		public Customizer<R4JCircuitBreakerFactory> defaultCustomizer() {
 			return factory -> factory.configureDefault(id -> new R4JConfigBuilder(id)
 					.timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(4)).build())
 					.circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())

--- a/spring-cloud-circuitbreaker-r4j/src/test/java/org/springframework/cloud/circuitbreaker/r4j/ReactiveR4JCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-r4j/src/test/java/org/springframework/cloud/circuitbreaker/r4j/ReactiveR4JCircuitBreakerIntegrationTest.java
@@ -58,23 +58,23 @@ public class ReactiveR4JCircuitBreakerIntegrationTest {
 	protected static class Application {
 		@RequestMapping("/slow")
 		public Mono<String> slow() throws InterruptedException {
-			return Mono.just("slow").delayElement(Duration.ofSeconds(3));
+			return Mono.just("slow").delayElement(Duration.ofSeconds(2));
 		}
 
 		@GetMapping("/normal")
 		public Mono<String> normal() {
-			return Mono.just("normal");
+			return Mono.just("normal").delayElement(Duration.ofSeconds(1));
 		}
 
 		@Bean
-		public Customizer<ReactiveCircuitBreakerFactory<R4JConfigBuilder.R4JCircuitBreakerConfiguration, R4JConfigBuilder>> slowCusomtizer() {
+		public Customizer<ReactiveR4JCircuitBreakerFactory> slowCusomtizer() {
 			return factory -> factory.configure("slow", builder -> builder
 			.timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(2)).build())
 			.circuitBreakerConfig(CircuitBreakerConfig.ofDefaults()));
 		}
 
 		@Bean
-		public Customizer<ReactiveCircuitBreakerFactory<R4JConfigBuilder.R4JCircuitBreakerConfiguration, R4JConfigBuilder>> defaultCustomizer() {
+		public Customizer<ReactiveR4JCircuitBreakerFactory> defaultCustomizer() {
 			return factory -> factory.configureDefault(id -> new R4JConfigBuilder(id)
 					.circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())
 					.timeLimiterConfig(TimeLimiterConfig.custom().timeoutDuration(Duration.ofSeconds(4)).build()).build());


### PR DESCRIPTION
so that auto configuration captures properly.

Currently, `Customizer<R4JCircuitBreakerFactory>` bean is not autowired.  This means `ReactiveR4JCircuitBreakerFactory#configureCircuitBreakerRegistry` is not available without casting from `CircuitBreakerFactory<R4JConfigBuilder.R4JCircuitBreakerConfiguration, R4JConfigBuilder>` to `R4JCircuitBreakerFactory`. This is not convenient and could cause misusage.
To fix this issue, this pr uses concrete concrete Factory class for customizers in auto configurations.

Actually, `@Bean public Customizer<HystrixCircuitBreakerFactory> customizer()` is used in `HystrixCircuitBreakerIntegrationTest`. I found customizers were not respected and integration tests did not make sense. It did not guarantee that customizers were used. Timeout for `normal` did not happen because it was faster than default timeout (1s) and timeout for `slow` happened because it was slower than default.
This pr also fixes sleeping times. 