### PR TITLE
Add NoFallbackAvailableException

### DIFF
--- a/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/NoFallbackAvailableException.java
+++ b/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/NoFallbackAvailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2018 the original author or authors.
+ * Copyright 2013-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,21 +15,14 @@
  */
 package org.springframework.cloud.circuitbreaker.commons;
 
-import java.util.function.Function;
-import java.util.function.Supplier;
-
 /**
- * Spring Cloud circuit breaker.
- * @author Ryan Baxter
+ * A runtime exception that tells no fallback is available for the circuit breaker.
+ *
+ * @author Toshiaki Maki
  */
-public interface CircuitBreaker {
+public class NoFallbackAvailableException extends RuntimeException {
 
-	default <T> T run(Supplier<T> toRun) {
-		return run(toRun, throwable -> {
-			throw new NoFallbackAvailableException("No fallback available.", throwable);
-		});
-	};
-
-	<T> T run(Supplier<T> toRun, Function<Throwable, T> fallback);
-
+	public NoFallbackAvailableException(String message, Throwable cause) {
+		super(message, cause);
+	}
 }

--- a/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactiveCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactiveCircuitBreaker.java
@@ -29,7 +29,7 @@ public interface ReactiveCircuitBreaker {
 
 	default <T> Mono<T> run(Mono<T> toRun) {
 		return run(toRun, throwable -> {
-			throw new UnsupportedOperationException("No fallback available.");
+			throw new NoFallbackAvailableException("No fallback available.", throwable);
 		});
 	}
 
@@ -37,7 +37,7 @@ public interface ReactiveCircuitBreaker {
 
 	default <T> Flux<T> run(Flux<T> toRun) {
 		return run(toRun, throwable -> {
-			throw new UnsupportedOperationException("No fallback available.");
+			throw new NoFallbackAvailableException("No fallback available.", throwable);
 		});
 	}
 


### PR DESCRIPTION
that replaces `UnsupportedOperationException`.

`UnsupportedOperationException` seems to be too generic to handle the exception properly when no fallback is set intentionally. Root cause should be also included.

I may prefer `run(toRun, Mono::error)`, but if telling `No fallback available` explicitly is by design I'd like to have a dedicated exception class.