### PR TITLE
Add reactive circuit breaker implementation of Sentinel

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker-sentinel.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker-sentinel.adoc
@@ -19,7 +19,7 @@ public Customizer<SentinelCircuitBreakerFactory> defaultCustomizer() {
 
 You can choose to provide default circuit breaking rules via `SentinelConfigBuilder#rules(rules)`.
 You can also choose to load circuit breaking rules later elsewhere using
-`DegradeRuleManager.loadRules(rules)` API of Sentinel.
+`DegradeRuleManager.loadRules(rules)` API of Sentinel, or via Sentinel dashboard.
 
 
 ===== Reactive Example

--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker-sentinel.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker-sentinel.adoc
@@ -3,7 +3,7 @@
 ==== Default Configuration
 
 To provide a default configuration for all of your circuit breakers create a `Customizer` bean that is passed a
-`SentinelCircuitBreakerFactory`.
+`SentinelCircuitBreakerFactory` or `ReactiveSentinelCircuitBreakerFactory`.
 The `configureDefault` method can be used to provide a default configuration.
 
 ====
@@ -20,6 +20,20 @@ public Customizer<SentinelCircuitBreakerFactory> defaultCustomizer() {
 You can choose to provide default circuit breaking rules via `SentinelConfigBuilder#rules(rules)`.
 You can also choose to load circuit breaking rules later elsewhere using
 `DegradeRuleManager.loadRules(rules)` API of Sentinel.
+
+
+===== Reactive Example
+
+====
+[source,java]
+----
+@Bean
+public Customizer<ReactiveSentinelCircuitBreakerFactory> defaultCustomizer() {
+	return factory -> factory.configureDefault(id -> new SentinelConfigBuilder(id)
+			.build());
+}
+----
+====
 
 
 ==== Specific Circuit Breaker Configuration
@@ -39,6 +53,23 @@ public Customizer<SentinelCircuitBreakerFactory> slowCustomizer() {
 			.setTimeWindow(10)
 		);
 	return factory -> factory.configure(builder -> builder.rules(rules), slowId);
+}
+----
+====
+
+===== Reactive Example
+
+====
+[source,java]
+----
+@Bean
+public Customizer<ReactiveSentinelCircuitBreakerFactory> customizer() {
+	List<DegradeRule> rules = Collections.singletonList(
+		new DegradeRule().setGrade(RuleConstant.DEGRADE_GRADE_RT)
+			.setCount(100)
+			.setTimeWindow(10)
+		);
+	return factory -> factory.configure(builder -> builder.rules(rules), "foo", "bar");
 }
 ----
 ====

--- a/spring-cloud-circuitbreaker-dependencies/pom.xml
+++ b/spring-cloud-circuitbreaker-dependencies/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <resilience4j.version>0.13.1</resilience4j.version>
-        <sentinel.version>1.5.0</sentinel.version>
+        <sentinel.version>1.5.1</sentinel.version>
     </properties>
 
     <dependencyManagement>

--- a/spring-cloud-circuitbreaker-sentinel/pom.xml
+++ b/spring-cloud-circuitbreaker-sentinel/pom.xml
@@ -45,5 +45,9 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+		</dependency>
     </dependencies>
 </project>

--- a/spring-cloud-circuitbreaker-sentinel/pom.xml
+++ b/spring-cloud-circuitbreaker-sentinel/pom.xml
@@ -48,6 +48,7 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
 		</dependency>
     </dependencies>
 </project>

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreaker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreaker.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.circuitbreaker.sentinel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.adapter.reactor.EntryConfig;
+import com.alibaba.csp.sentinel.adapter.reactor.SentinelReactorTransformer;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
+import org.springframework.util.Assert;
+
+/**
+ * Sentinel implementation of {@link ReactiveCircuitBreaker}.
+ *
+ * @author Eric Zhao
+ */
+public class ReactiveSentinelCircuitBreaker implements ReactiveCircuitBreaker {
+
+	private final String resourceName;
+
+	private final EntryType entryType;
+
+	private final List<DegradeRule> rules;
+
+	public ReactiveSentinelCircuitBreaker(String resourceName, EntryType entryType,
+			List<DegradeRule> rules) {
+		Assert.hasText(resourceName, "resourceName cannot be blank");
+		Assert.notNull(rules, "rules should not be null");
+		this.resourceName = resourceName;
+		this.entryType = entryType;
+		this.rules = Collections.unmodifiableList(rules);
+
+		applyToSentinelRuleManager();
+	}
+
+	public ReactiveSentinelCircuitBreaker(String resourceName, List<DegradeRule> rules) {
+		this(resourceName, EntryType.OUT, rules);
+	}
+
+	public ReactiveSentinelCircuitBreaker(String resourceName) {
+		this(resourceName, EntryType.OUT, Collections.emptyList());
+	}
+
+	private void applyToSentinelRuleManager() {
+		if (this.rules == null || this.rules.isEmpty()) {
+			return;
+		}
+		Set<DegradeRule> ruleSet = new HashSet<>(DegradeRuleManager.getRules());
+		for (DegradeRule rule : this.rules) {
+			if (rule == null) {
+				continue;
+			}
+			rule.setResource(resourceName);
+			ruleSet.add(rule);
+		}
+		DegradeRuleManager.loadRules(new ArrayList<>(ruleSet));
+	}
+
+	@Override
+	public <T> Mono<T> run(Mono<T> toRun, Function<Throwable, Mono<T>> fallback) {
+		Mono<T> toReturn = toRun.transform(new SentinelReactorTransformer<>(
+				new EntryConfig(resourceName, entryType)));
+		if (fallback != null) {
+			toReturn = toReturn.onErrorResume(fallback);
+		}
+		return toReturn;
+	}
+
+	@Override
+	public <T> Flux<T> run(Flux<T> toRun, Function<Throwable, Flux<T>> fallback) {
+		Flux<T> toReturn = toRun.transform(new SentinelReactorTransformer<>(
+				new EntryConfig(resourceName, entryType)));
+		if (fallback != null) {
+			toReturn = toReturn.onErrorResume(fallback);
+		}
+		return toReturn;
+	}
+
+}

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerAutoConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.circuitbreaker.sentinel;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.circuitbreaker.commons.Customizer;
+import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Eric Zhao
+ */
+@Configuration
+@ConditionalOnClass(name = { "reactor.core.publisher.Mono",
+		"reactor.core.publisher.Flux" })
+public class ReactiveSentinelCircuitBreakerAutoConfiguration {
+
+	@Bean
+	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
+
+	public ReactiveCircuitBreakerFactory reactiveSentinelCircuitBreakerFactory() {
+		return new ReactiveSentinelCircuitBreakerFactory();
+	}
+
+	@Configuration
+	@ConditionalOnClass(name = { "reactor.core.publisher.Mono",
+			"reactor.core.publisher.Flux" })
+	public static class ReactiveSentinelCustomizerConfiguration {
+
+		@Autowired(required = false)
+		private List<Customizer<ReactiveSentinelCircuitBreakerFactory>> customizers = new ArrayList<>();
+
+		@Autowired(required = false)
+		private ReactiveSentinelCircuitBreakerFactory factory;
+
+		@PostConstruct
+		public void init() {
+			customizers.forEach(customizer -> customizer.customize(factory));
+		}
+
+	}
+
+}

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.circuitbreaker.sentinel;
+
+import java.util.ArrayList;
+import java.util.function.Function;
+
+import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.sentinel.SentinelConfigBuilder.SentinelCircuitBreakerConfiguration;
+import org.springframework.util.Assert;
+
+/**
+ * Factory for {@link ReactiveSentinelCircuitBreaker}.
+ *
+ * @author Eric Zhao
+ */
+public class ReactiveSentinelCircuitBreakerFactory extends
+		ReactiveCircuitBreakerFactory<SentinelConfigBuilder.SentinelCircuitBreakerConfiguration, SentinelConfigBuilder> {
+
+	private Function<String, SentinelConfigBuilder.SentinelCircuitBreakerConfiguration> defaultConfiguration = id -> new SentinelConfigBuilder()
+			.resourceName(id).rules(new ArrayList<>()).build();
+
+	@Override
+	public ReactiveCircuitBreaker create(String id) {
+		Assert.hasText(id, "A CircuitBreaker must have an id.");
+		SentinelConfigBuilder.SentinelCircuitBreakerConfiguration conf = getConfigurations()
+				.computeIfAbsent(id, defaultConfiguration);
+		return new ReactiveSentinelCircuitBreaker(id, conf.getEntryType(),
+				conf.getRules());
+	}
+
+	@Override
+	protected SentinelConfigBuilder configBuilder(String id) {
+		return new SentinelConfigBuilder(id);
+	}
+
+	@Override
+	public void configureDefault(
+			Function<String, SentinelCircuitBreakerConfiguration> defaultConfiguration) {
+		this.defaultConfiguration = defaultConfiguration;
+	}
+
+}

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreaker.java
@@ -49,7 +49,7 @@ public class SentinelCircuitBreaker implements CircuitBreaker {
 	private final List<DegradeRule> rules;
 
 	public SentinelCircuitBreaker(String resourceName, EntryType entryType,
-			List<DegradeRule> rules) {
+		List<DegradeRule> rules) {
 		Assert.hasText(resourceName, "resourceName cannot be blank");
 		Assert.notNull(rules, "rules should not be null");
 		this.resourceName = resourceName;
@@ -72,7 +72,13 @@ public class SentinelCircuitBreaker implements CircuitBreaker {
 			return;
 		}
 		Set<DegradeRule> ruleSet = new HashSet<>(DegradeRuleManager.getRules());
-		ruleSet.addAll(this.rules);
+		for (DegradeRule rule : this.rules) {
+			if (rule == null) {
+				continue;
+			}
+			rule.setResource(resourceName);
+			ruleSet.add(rule);
+		}
 		DegradeRuleManager.loadRules(new ArrayList<>(ruleSet));
 	}
 

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerFactory.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.circuitbreaker.sentinel;
 import java.util.ArrayList;
 import java.util.function.Function;
 
+import com.alibaba.csp.sentinel.EntryType;
+
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreaker;
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreakerFactory;
 import org.springframework.cloud.circuitbreaker.sentinel.SentinelConfigBuilder.SentinelCircuitBreakerConfiguration;
@@ -28,16 +30,19 @@ import org.springframework.util.Assert;
  * @author Eric Zhao
  */
 public class SentinelCircuitBreakerFactory extends
-		CircuitBreakerFactory<SentinelConfigBuilder.SentinelCircuitBreakerConfiguration, SentinelConfigBuilder> {
+	CircuitBreakerFactory<SentinelConfigBuilder.SentinelCircuitBreakerConfiguration, SentinelConfigBuilder> {
 
 	private Function<String, SentinelConfigBuilder.SentinelCircuitBreakerConfiguration> defaultConfiguration = id -> new SentinelConfigBuilder()
-			.resourceName(id).rules(new ArrayList<>()).build();
+		.resourceName(id)
+		.entryType(EntryType.OUT)
+		.rules(new ArrayList<>())
+		.build();
 
 	@Override
 	public CircuitBreaker create(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		SentinelConfigBuilder.SentinelCircuitBreakerConfiguration conf = getConfigurations()
-				.computeIfAbsent(id, defaultConfiguration);
+			.computeIfAbsent(id, defaultConfiguration);
 		return new SentinelCircuitBreaker(id, conf.getEntryType(), conf.getRules());
 	}
 
@@ -48,7 +53,7 @@ public class SentinelCircuitBreakerFactory extends
 
 	@Override
 	public void configureDefault(
-			Function<String, SentinelCircuitBreakerConfiguration> defaultConfiguration) {
+		Function<String, SentinelCircuitBreakerConfiguration> defaultConfiguration) {
 		this.defaultConfiguration = defaultConfiguration;
 	}
 

--- a/spring-cloud-circuitbreaker-sentinel/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.circuitbreaker.sentinel.SentinelCircuitBreakerAutoConfiguration
+org.springframework.cloud.circuitbreaker.sentinel.SentinelCircuitBreakerAutoConfiguration,\
+org.springframework.cloud.circuitbreaker.sentinel.ReactiveSentinelCircuitBreakerAutoConfiguration

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerIntegrationTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.circuitbreaker.sentinel;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import com.alibaba.csp.sentinel.slots.block.RuleConstant;
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.circuitbreaker.commons.Customizer;
+import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Ryan Baxter
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT, classes = ReactiveSentinelCircuitBreakerIntegrationTest.Application.class)
+@DirtiesContext
+public class ReactiveSentinelCircuitBreakerIntegrationTest {
+
+	@LocalServerPort
+	private int port = 0;
+
+	@Autowired
+	private ReactiveSentinelCircuitBreakerIntegrationTest.Application.DemoControllerService service;
+
+	@Before
+	public void setup() {
+		service.setPort(port);
+	}
+
+	@Test
+	public void test() throws Exception {
+		StepVerifier.create(service.normal()).expectNext("normal").verifyComplete();
+		StepVerifier.create(service.slow()).expectNext("slow").verifyComplete();
+		StepVerifier.create(service.slow()).expectNext("slow").verifyComplete();
+		StepVerifier.create(service.slow()).expectNext("slow").verifyComplete();
+		StepVerifier.create(service.slow()).expectNext("slow").verifyComplete();
+		StepVerifier.create(service.slow()).expectNext("slow").verifyComplete();
+
+		// Then in the next 5s, the fallback method should be called.
+		for (int i = 0; i < 5; i++) {
+			StepVerifier.create(service.slow()).expectNext("fallback").verifyComplete();
+			Thread.sleep(1000);
+		}
+
+		// Recovered.
+		StepVerifier.create(service.slow()).expectNext("slow").verifyComplete();
+
+		StepVerifier.create(service.normalFlux()).expectNext("normalflux")
+				.verifyComplete();
+		StepVerifier.create(service.slowFlux()).expectNext("slowflux").verifyComplete();
+		StepVerifier.create(service.slowFlux()).expectNext("slowflux").verifyComplete();
+		StepVerifier.create(service.slowFlux()).expectNext("slowflux").verifyComplete();
+		StepVerifier.create(service.slowFlux()).expectNext("slowflux").verifyComplete();
+		StepVerifier.create(service.slowFlux()).expectNext("slowflux").verifyComplete();
+		// Then in the next 5s, the fallback method should be called.
+		for (int i = 0; i < 5; i++) {
+			StepVerifier.create(service.slowFlux()).expectNext("flux_fallback")
+					.verifyComplete();
+			Thread.sleep(1000);
+		}
+
+		// Recovered.
+		StepVerifier.create(service.slowFlux()).expectNext("slowflux").verifyComplete();
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@RestController
+	protected static class Application {
+
+		@GetMapping("/slow")
+		public Mono<String> slow() {
+			return Mono.just("slow").delayElement(Duration.ofMillis(500));
+		}
+
+		@GetMapping("/normal")
+		public Mono<String> normal() {
+			return Mono.just("normal");
+		}
+
+		@GetMapping("/slow_flux")
+		public Flux<String> slowFlux() {
+			return Flux.just("slow", "flux").delayElements(Duration.ofMillis(500));
+		}
+
+		@GetMapping("normal_flux")
+		public Flux<String> normalFlux() {
+			return Flux.just("normal", "flux");
+		}
+
+		@Bean
+		public Customizer<ReactiveSentinelCircuitBreakerFactory> slowCustomizer() {
+			return factory -> {
+				factory.configure(builder -> builder
+						.rules(Collections.singletonList(new DegradeRule("slow_mono")
+								.setGrade(RuleConstant.DEGRADE_GRADE_RT).setCount(100)
+								.setTimeWindow(5))),
+						"slow_mono");
+				factory.configure(builder -> builder
+						.rules(Collections.singletonList(new DegradeRule("slow_flux")
+								.setGrade(RuleConstant.DEGRADE_GRADE_RT).setCount(100)
+								.setTimeWindow(5))),
+						"slow_flux");
+				factory.configureDefault(id -> new SentinelConfigBuilder()
+						.resourceName(id)
+						.rules(Collections.singletonList(new DegradeRule(id)
+								.setGrade(RuleConstant.DEGRADE_GRADE_EXCEPTION_COUNT)
+								.setCount(0.5).setTimeWindow(10)))
+						.build());
+			};
+		}
+
+		@Service
+		public static class DemoControllerService {
+
+			private int port = 0;
+
+			private ReactiveCircuitBreakerFactory cbFactory;
+
+			DemoControllerService(ReactiveCircuitBreakerFactory cbFactory) {
+				this.cbFactory = cbFactory;
+			}
+
+			public Mono<String> slow() {
+				return cbFactory.create("slow_mono").run(
+						WebClient.builder().baseUrl("http://localhost:" + port).build()
+								.get().uri("/slow").retrieve().bodyToMono(String.class),
+						t -> {
+							t.printStackTrace();
+							return Mono.just("fallback");
+						});
+			}
+
+			public Mono<String> normal() {
+				return cbFactory.create("normal_mono").run(
+						WebClient.builder().baseUrl("http://localhost:" + port).build()
+								.get().uri("/normal").retrieve().bodyToMono(String.class),
+						t -> {
+							t.printStackTrace();
+							return Mono.just("fallback");
+						});
+			}
+
+			public Flux<String> slowFlux() {
+				return cbFactory.create("slow_flux")
+						.run(WebClient.builder().baseUrl("http://localhost:" + port)
+								.build().get().uri("/slow_flux").retrieve()
+								.bodyToFlux(new ParameterizedTypeReference<String>() {
+								}), t -> {
+									t.printStackTrace();
+									return Flux.just("flux_fallback");
+								});
+			}
+
+			public Flux<String> normalFlux() {
+				return cbFactory.create("normal_flux")
+						.run(WebClient.builder().baseUrl("http://localhost:" + port)
+								.build().get().uri("/normal_flux").retrieve()
+								.bodyToFlux(String.class), t -> {
+									t.printStackTrace();
+									return Flux.just("flux_fallback");
+								});
+			}
+
+			public void setPort(int port) {
+				this.port = port;
+			}
+
+		}
+
+	}
+
+}

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerTest.java
@@ -17,7 +17,9 @@
 package org.springframework.cloud.circuitbreaker.sentinel;
 
 import java.util.Arrays;
+import java.util.Collections;
 
+import com.alibaba.csp.sentinel.slots.block.degrade.DegradeRuleManager;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -30,6 +32,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Eric Zhao
  */
 public class ReactiveSentinelCircuitBreakerTest {
+
+	@Test
+	public void testCreateWithNullRule() {
+		String id = "testCreateReactiveCbWithNullRule";
+		ReactiveSentinelCircuitBreaker cb = new ReactiveSentinelCircuitBreaker(id, Collections.singletonList(null));
+		assertThat(cb.run(Mono.just("foobar")).block()).isEqualTo("foobar");
+		assertThat(DegradeRuleManager.hasConfig(id)).isFalse();
+	}
 
 	@Test
 	public void runMono() {

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.circuitbreaker.sentinel;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Eric Zhao
+ */
+public class ReactiveSentinelCircuitBreakerTest {
+
+	@Test
+	public void runMono() {
+		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
+				.create("foo");
+		assertThat(cb.run(Mono.just("foobar")).block()).isEqualTo("foobar");
+	}
+
+	@Test
+	public void runMonoWithFallback() {
+		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
+				.create("foo");
+		assertThat(cb
+				.run(Mono.error(new RuntimeException("boom")), t -> Mono.just("fallback"))
+				.block()).isEqualTo("fallback");
+	}
+
+	@Test
+	public void runFlux() {
+		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
+				.create("foo");
+		assertThat(cb.run(Flux.just("foobar", "hello world")).collectList().block())
+				.isEqualTo(Arrays.asList("foobar", "hello world"));
+	}
+
+	@Test
+	public void runFluxWithFallback() {
+		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
+				.create("foo");
+		assertThat(cb
+				.run(Flux.error(new RuntimeException("boom")), t -> Flux.just("fallback"))
+				.collectList().block()).isEqualTo(Arrays.asList("fallback"));
+	}
+
+}

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerTest.java
@@ -43,19 +43,27 @@ public class SentinelCircuitBreakerTest {
 	public void testCreateDirectlyThenRun() {
 		// Create a circuit breaker without any circuit breaking rules.
 		CircuitBreaker cb = new SentinelCircuitBreaker(
-				"testSentinelCreateDirectlyThenRunA");
+			"testSentinelCreateDirectlyThenRunA");
 		assertThat(cb.run(() -> "Sentinel")).isEqualTo("Sentinel");
 		assertThat(DegradeRuleManager.hasConfig("testSentinelCreateDirectlyThenRunA"))
-				.isFalse();
+			.isFalse();
 
 		CircuitBreaker cb2 = new SentinelCircuitBreaker(
-				"testSentinelCreateDirectlyThenRunB",
-				Collections.singletonList(
-						new DegradeRule("testSentinelCreateDirectlyThenRunB")
-								.setCount(100).setTimeWindow(10)));
+			"testSentinelCreateDirectlyThenRunB",
+			Collections.singletonList(
+				new DegradeRule("testSentinelCreateDirectlyThenRunB")
+					.setCount(100).setTimeWindow(10)));
 		assertThat(cb2.run(() -> "Sentinel")).isEqualTo("Sentinel");
 		assertThat(DegradeRuleManager.hasConfig("testSentinelCreateDirectlyThenRunB"))
-				.isTrue();
+			.isTrue();
+	}
+
+	@Test
+	public void testCreateWithNullRule() {
+		String id = "testCreateCbWithNullRule";
+		CircuitBreaker cb = new SentinelCircuitBreaker(id, Collections.singletonList(null));
+		assertThat(cb.run(() -> "Sentinel")).isEqualTo("Sentinel");
+		assertThat(DegradeRuleManager.hasConfig(id)).isFalse();
 	}
 
 	@Test
@@ -67,7 +75,7 @@ public class SentinelCircuitBreakerTest {
 	@Test
 	public void testRunWithFallback() {
 		CircuitBreaker cb = new SentinelCircuitBreakerFactory()
-				.create("testSentinelRunWithFallback");
+			.create("testSentinelRunWithFallback");
 		assertThat(cb.<String>run(() -> {
 			throw new RuntimeException("boom");
 		}, t -> "fallback")).isEqualTo("fallback");


### PR DESCRIPTION
This PR adds reactive circuit breaker implementation of [Sentinel](https://github.com/alibaba/Sentinel/) in `spring-cloud-circuitbreaker-sentinel`. The reactive integration leverages [sentinel-reactor-adapter](https://github.com/alibaba/Sentinel/tree/master/sentinel-adapter/sentinel-reactor-adapter) module. The implementation follows the interfaces listed in common module.

This PR will close #12.