### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,8 +10,8 @@ image::https://api.codacy.com/project/badge/Grade/a6885a06921e4f72a0df0b7aabd6d1
 
 :github-tag: master
 :github-repo: spring-cloud-incubator/spring-cloud-circuitbreaker
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :all: {asterisk}{asterisk}
 :nofooter:
 :branch: master
@@ -290,7 +290,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -312,13 +312,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -377,7 +377,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -390,7 +390,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -461,7 +461,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud-incubator/spring-cloud-circuitbreaker
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :all: {asterisk}{asterisk}
 :nofooter:
 :branch: master

--- a/js/highlight/styles/dracula.min.css
+++ b/js/highlight/styles/dracula.min.css
@@ -7,7 +7,7 @@ https://github.com/zenorocha/dracula-theme
 Copyright 2015, All rights reserved
 
 Code licensed under the MIT license
-http://zenorocha.mit-license.org
+https://zenorocha.mit-license.org/
 
 @author Éverton Ribeiro <nuxlli@gmail.com>
 @author Zeno Rocha <hi@zenorocha.com>

--- a/js/highlight/styles/monokai-sublime.min.css
+++ b/js/highlight/styles/monokai-sublime.min.css
@@ -1,6 +1,6 @@
 /*
 
-Monokai Sublime style. Derived from Monokai by noformnocontent http://nn.mit-license.org/
+Monokai Sublime style. Derived from Monokai by noformnocontent https://nn.mit-license.org/
 
 */
 

--- a/js/highlight/styles/monokai.min.css
+++ b/js/highlight/styles/monokai.min.css
@@ -1,5 +1,5 @@
 /*
-Monokai style - ported by Luigi Maselli - http://grigio.org
+Monokai style - ported by Luigi Maselli - https://grigio.org
 */
 
 .hljs {

--- a/spring-cloud-circuitbreaker.html
+++ b/spring-cloud-circuitbreaker.html
@@ -33,7 +33,7 @@
 	color: #ffffff;
 }
 </style>
-<script src="http://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js"></script>
 <script type="text/javascript">
 function addBlockSwitches() {
 	$('.primary').each(function() {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://zenorocha.mit-license.org (301) with 1 occurrences migrated to:  
  https://zenorocha.mit-license.org/ ([https](https://zenorocha.mit-license.org) result NullPointerException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js with 1 occurrences migrated to:  
  https://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js ([https](https://cdnjs.cloudflare.com/ajax/libs/zepto/1.2.0/zepto.min.js) result 200).
* [ ] http://github.com/ with 2 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://grigio.org with 1 occurrences migrated to:  
  https://grigio.org ([https](https://grigio.org) result 200).
* [ ] http://nn.mit-license.org/ with 1 occurrences migrated to:  
  https://nn.mit-license.org/ ([https](https://nn.mit-license.org/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 1 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://raw.github.com/ with 2 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 6 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences
* http://www.w3.org/1999/xlink with 1 occurrences
* http://www.w3.org/2000/svg with 1 occurrences