### PR TITLE
Stop lengthy requests blocking subsequent circuit breaker calls

### DIFF
--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerFactory.java
@@ -45,7 +45,7 @@ public class Resilience4JCircuitBreakerFactory extends
 	private CircuitBreakerRegistry circuitBreakerRegistry = CircuitBreakerRegistry
 			.ofDefaults();
 
-	private ExecutorService executorService = Executors.newSingleThreadExecutor();
+	private ExecutorService executorService = Executors.newCachedThreadPool();
 
 	private Map<String, Customizer<CircuitBreaker>> circuitBreakerCustomizers = new HashMap<>();
 

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerIntegrationTest.java
@@ -35,10 +35,14 @@ import org.springframework.cloud.circuitbreaker.commons.CircuitBreakerFactory;
 import org.springframework.cloud.circuitbreaker.commons.Customizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,6 +88,12 @@ public class Resilience4JCircuitBreakerIntegrationTest {
 		verify(normalSuccessConsumer, times(1)).consumeEvent(any());
 	}
 
+	@Test
+	public void testSlowResponsesDontFailSubsequentGoodRequests() {
+		assertThat(service.slowOnDemand(5000)).isEqualTo("fallback");
+		assertThat(service.slowOnDemand(0)).isEqualTo("normal");
+	}
+
 	@Configuration
 	@EnableAutoConfiguration
 	@RestController
@@ -97,6 +107,23 @@ public class Resilience4JCircuitBreakerIntegrationTest {
 
 		@GetMapping("/normal")
 		public String normal() {
+			return "normal";
+		}
+
+		@GetMapping("/slowOnDemand")
+		public String slowOnDemand(@RequestHeader HttpHeaders headers) {
+			if (headers.containsKey("delayInMilliseconds")) {
+				String delayString = headers.getFirst("delayInMilliseconds");
+				if (delayString != null) {
+					try {
+						Thread.sleep(Integer.parseInt(delayString));
+					}
+					catch (NumberFormatException | InterruptedException e) {
+						e.printStackTrace();
+					}
+				}
+			}
+
 			return "normal";
 		}
 
@@ -144,6 +171,26 @@ public class Resilience4JCircuitBreakerIntegrationTest {
 				return cbFactory.create("normal").run(
 						() -> rest.getForObject("/normal", String.class),
 						t -> "fallback");
+			}
+
+			public String slowOnDemand(int delayInMilliseconds) {
+				return cbFactory.create("slow")
+						.run(() -> rest
+								.exchange("/slowOnDemand", HttpMethod.GET,
+										createEntityWithOptionalDelayHeader(
+												delayInMilliseconds),
+										String.class)
+								.getBody(), t -> "fallback");
+			}
+
+			private HttpEntity<String> createEntityWithOptionalDelayHeader(
+					int delayInMilliseconds) {
+				HttpHeaders headers = new HttpHeaders();
+				if (delayInMilliseconds > 0) {
+					headers.set("delayInMilliseconds",
+							Integer.toString(delayInMilliseconds));
+				}
+				return new HttpEntity<>(null, headers);
 			}
 
 		}


### PR DESCRIPTION
* Replace choice of ExecutorService in Resilience4JCircuitBreakerFactory with
  cached thread pool alternative
* Added failing test to demonstrate the problem
* Fixes issue gh-25