### PR TITLE
Support For Publishers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -53,7 +53,7 @@ public static class DemoControllerService {
 	}
 
 	public String slow() {
-		return cbFactory.create("slow").run(() -> rest.getForObject("/slow", String.class), throwable -> "fallback");
+		return cbFactory.createReactor("slow").run(() -> rest.getForObject("/slow", String.class), throwable -> "fallback");
 	}
 
 }
@@ -86,7 +86,7 @@ public static class DemoControllerService {
 	}
 
 	public Mono<String> slow() {
-		return cbFactory.create("slow").run(webClient.get().uri("/slow").retrieve().bodyToMono(String.class),
+		return cbFactory.createReactor("slow").run(webClient.get().uri("/slow").retrieve().bodyToMono(String.class),
 		throwable -> return Mono.just("fallback"));
 	}
 }

--- a/docs/src/main/asciidoc/spring-cloud-circuitbreaker.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-circuitbreaker.adoc
@@ -43,7 +43,7 @@ public static class DemoControllerService {
 	}
 
 	public String slow() {
-		return cbFactory.create("slow").run(() -> rest.getForObject("/slow", String.class), throwable -> "fallback");
+		return cbFactory.createReactor("slow").run(() -> rest.getForObject("/slow", String.class), throwable -> "fallback");
 	}
 
 }
@@ -77,7 +77,7 @@ public static class DemoControllerService {
 
 	public Mono<String> slow() {
 		return webClient.get().uri("/slow").retrieve().bodyToMono(String.class).transform(
-		it -> cbFactory.create("slow").run(it, throwable -> return Mono.just("fallback")));
+		it -> cbFactory.createReactor("slow").run(it, throwable -> return Mono.just("fallback")));
 	}
 }
 ----

--- a/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/CircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/CircuitBreakerFactory.java
@@ -24,6 +24,6 @@ package org.springframework.cloud.circuitbreaker.commons;
 public abstract class CircuitBreakerFactory<CONF, CONFB extends ConfigBuilder<CONF>>
 		extends AbstractCircuitBreakerFactory<CONF, CONFB> {
 
-	public abstract CircuitBreaker create(String id);
+	public abstract CircuitBreaker createReactor(String id);
 
 }

--- a/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactorCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactorCircuitBreaker.java
@@ -29,17 +29,15 @@ import reactor.core.publisher.Mono;
 public interface ReactorCircuitBreaker {
 
 	default <T> Mono<T> run(Mono<T> toRun) {
-		return run(toRun, throwable -> {
-			throw new NoFallbackAvailableException("No fallback available.", throwable);
-		});
+		return run(toRun, throwable -> Mono.error(
+				new NoFallbackAvailableException("No fallback available.", throwable)));
 	}
 
 	<T> Mono<T> run(Mono<T> toRun, Function<Throwable, Mono<T>> fallback);
 
 	default <T> Flux<T> run(Flux<T> toRun) {
-		return run(toRun, throwable -> {
-			throw new NoFallbackAvailableException("No fallback available.", throwable);
-		});
+		return run(toRun, throwable -> Flux.error(
+				new NoFallbackAvailableException("No fallback available.", throwable)));
 	}
 
 	<T> Flux<T> run(Flux<T> toRun, Function<Throwable, Flux<T>> fallback);

--- a/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactorCircuitBreaker.java
+++ b/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactorCircuitBreaker.java
@@ -18,19 +18,30 @@ package org.springframework.cloud.circuitbreaker.commons;
 
 import java.util.function.Function;
 
-import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
+ * Spring Cloud reactor circuit breaker API.
+ *
  * @author Ryan Baxter
  */
-public interface ReactiveCircuitBreaker {
+public interface ReactorCircuitBreaker {
 
-	default <T> Publisher<T> run(Publisher<T> toRun) {
+	default <T> Mono<T> run(Mono<T> toRun) {
 		return run(toRun, throwable -> {
 			throw new NoFallbackAvailableException("No fallback available.", throwable);
 		});
 	}
 
-	<T> Publisher<T> run(Publisher<T> toRun, Function<Throwable, Publisher<T>> fallback);
+	<T> Mono<T> run(Mono<T> toRun, Function<Throwable, Mono<T>> fallback);
+
+	default <T> Flux<T> run(Flux<T> toRun) {
+		return run(toRun, throwable -> {
+			throw new NoFallbackAvailableException("No fallback available.", throwable);
+		});
+	}
+
+	<T> Flux<T> run(Flux<T> toRun, Function<Throwable, Flux<T>> fallback);
 
 }

--- a/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactorCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-commons/src/main/java/org/springframework/cloud/circuitbreaker/commons/ReactorCircuitBreakerFactory.java
@@ -21,9 +21,11 @@ package org.springframework.cloud.circuitbreaker.commons;
  *
  * @author Ryan Baxter
  */
-public abstract class ReactiveCircuitBreakerFactory<CONF, CONFB extends ConfigBuilder<CONF>>
+public abstract class ReactorCircuitBreakerFactory<CONF, CONFB extends ConfigBuilder<CONF>>
 		extends AbstractCircuitBreakerFactory<CONF, CONFB> {
 
-	public abstract ReactiveCircuitBreaker create(String id);
+	public abstract ReactorCircuitBreaker createReactor(String id);
+
+	public abstract ReactiveCircuitBreaker createReactive(String id);
 
 }

--- a/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerAutoConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.circuitbreaker.commons.CircuitBreakerFactory;
 import org.springframework.cloud.circuitbreaker.commons.Customizer;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -46,11 +46,11 @@ public class HystrixCircuitBreakerAutoConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
+	@ConditionalOnMissingBean(ReactorCircuitBreakerFactory.class)
 	@ConditionalOnClass(
 			name = { "reactor.core.publisher.Mono", "reactor.core.publisher.Flux" })
-	public ReactiveHystrixCircuitBreakerFactory reactiveHystrixCircuitBreakerFactory() {
-		return new ReactiveHystrixCircuitBreakerFactory();
+	public ReactorHystrixCircuitBreakerFactory reactiveHystrixCircuitBreakerFactory() {
+		return new ReactorHystrixCircuitBreakerFactory();
 	}
 
 	@Configuration
@@ -75,10 +75,10 @@ public class HystrixCircuitBreakerAutoConfiguration {
 	protected static class ReactiveHystrixCircuitBreakerCustomizerConfiguration {
 
 		@Autowired(required = false)
-		private List<Customizer<ReactiveHystrixCircuitBreakerFactory>> customizers = new ArrayList<>();
+		private List<Customizer<ReactorHystrixCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired(required = false)
-		private ReactiveHystrixCircuitBreakerFactory factory;
+		private ReactorHystrixCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {

--- a/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerFactory.java
@@ -44,7 +44,7 @@ public class HystrixCircuitBreakerFactory extends
 		return new HystrixConfigBuilder(id);
 	}
 
-	public HystrixCircuitBreaker create(String id) {
+	public HystrixCircuitBreaker createReactor(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		HystrixCommand.Setter setter = getConfigurations().computeIfAbsent(id,
 				defaultConfiguration);

--- a/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/ReactorHystrixCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/main/java/org/springframework/cloud/circuitbreaker/hystrix/ReactorHystrixCircuitBreakerFactory.java
@@ -22,14 +22,15 @@ import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixObservableCommand;
 
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.util.Assert;
 
 /**
  * @author Ryan Baxter
  */
-public class ReactiveHystrixCircuitBreakerFactory extends
-		ReactiveCircuitBreakerFactory<HystrixObservableCommand.Setter, ReactiveHystrixCircuitBreakerFactory.ReactiveHystrixConfigBuilder> {
+public class ReactorHystrixCircuitBreakerFactory extends
+		ReactorCircuitBreakerFactory<HystrixObservableCommand.Setter, ReactorHystrixCircuitBreakerFactory.ReactiveHystrixConfigBuilder> {
 
 	private Function<String, HystrixObservableCommand.Setter> defaultConfiguration = id -> HystrixObservableCommand.Setter
 			.withGroupKey(HystrixCommandGroupKey.Factory.asKey(id));
@@ -46,11 +47,20 @@ public class ReactiveHystrixCircuitBreakerFactory extends
 	}
 
 	@Override
-	public ReactiveCircuitBreaker create(String id) {
+	public ReactorCircuitBreaker createReactor(String id) {
+		return createReactorHystrixCircuitBreaker(id);
+	}
+
+	private ReactorHystrixCircuitBreaker createReactorHystrixCircuitBreaker(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		HystrixObservableCommand.Setter setter = getConfigurations().computeIfAbsent(id,
 				defaultConfiguration);
-		return new ReactiveHystrixCircuitBreaker(setter);
+		return new ReactorHystrixCircuitBreaker(setter);
+	}
+
+	@Override
+	public ReactiveCircuitBreaker createReactive(String id) {
+		return createReactorHystrixCircuitBreaker(id);
 	}
 
 	public static class ReactiveHystrixConfigBuilder

--- a/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerIntegrationTest.java
@@ -109,12 +109,12 @@ public class HystrixCircuitBreakerIntegrationTest {
 			}
 
 			public String slow() {
-				return cbFactory.create("slow").run(
+				return cbFactory.createReactor("slow").run(
 						() -> rest.getForObject("/slow", String.class), t -> "fallback");
 			}
 
 			public String normal() {
-				return cbFactory.create("normal").run(
+				return cbFactory.createReactor("normal").run(
 						() -> rest.getForObject("/normal", String.class),
 						t -> "fallback");
 			}

--- a/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/HystrixCircuitBreakerTest.java
@@ -29,14 +29,14 @@ public class HystrixCircuitBreakerTest {
 
 	@Test
 	public void run() {
-		CircuitBreaker cb = new HystrixCircuitBreakerFactory().create("foo");
+		CircuitBreaker cb = new HystrixCircuitBreakerFactory().createReactor("foo");
 		String s = cb.run(() -> "foobar", t -> "fallback");
 		assertThat(cb.run(() -> "foobar", t -> "fallback")).isEqualTo("foobar");
 	}
 
 	@Test
 	public void fallback() {
-		CircuitBreaker cb = new HystrixCircuitBreakerFactory().create("foo");
+		CircuitBreaker cb = new HystrixCircuitBreakerFactory().createReactor("foo");
 		assertThat((String) cb.run(() -> {
 			throw new RuntimeException("Boom");
 		}, t -> "fallback")).isEqualTo("fallback");

--- a/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/ReactorHystrixCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/ReactorHystrixCircuitBreakerIntegrationTest.java
@@ -31,7 +31,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.cloud.circuitbreaker.commons.Customizer;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
@@ -50,15 +50,15 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT,
-		classes = ReactiveHystrixCircuitBreakerIntegrationTest.Application.class)
+		classes = ReactorHystrixCircuitBreakerIntegrationTest.Application.class)
 @DirtiesContext
-public class ReactiveHystrixCircuitBreakerIntegrationTest {
+public class ReactorHystrixCircuitBreakerIntegrationTest {
 
 	@LocalServerPort
 	int port = 0;
 
 	@Autowired
-	ReactiveHystrixCircuitBreakerIntegrationTest.Application.DemoControllerService service;
+	ReactorHystrixCircuitBreakerIntegrationTest.Application.DemoControllerService service;
 
 	@Before
 	public void setup() {
@@ -91,7 +91,7 @@ public class ReactiveHystrixCircuitBreakerIntegrationTest {
 		}
 
 		@Bean
-		public Customizer<ReactiveHystrixCircuitBreakerFactory> customizer() {
+		public Customizer<ReactorHystrixCircuitBreakerFactory> customizer() {
 			return factory -> factory
 					.configure(
 							builder -> builder.commandProperties(HystrixCommandProperties
@@ -100,7 +100,7 @@ public class ReactiveHystrixCircuitBreakerIntegrationTest {
 		}
 
 		@Bean
-		public Customizer<ReactiveHystrixCircuitBreakerFactory> defaultConfig() {
+		public Customizer<ReactorHystrixCircuitBreakerFactory> defaultConfig() {
 			return factory -> factory
 					.configureDefault(id -> HystrixObservableCommand.Setter
 							.withGroupKey(HystrixCommandGroupKey.Factory.asKey(id))
@@ -113,16 +113,16 @@ public class ReactiveHystrixCircuitBreakerIntegrationTest {
 
 			private int port = 0;
 
-			private ReactiveCircuitBreakerFactory cbFactory;
+			private ReactorCircuitBreakerFactory cbFactory;
 
-			DemoControllerService(ReactiveCircuitBreakerFactory cbBuilder) {
+			DemoControllerService(ReactorCircuitBreakerFactory cbBuilder) {
 				this.cbFactory = cbBuilder;
 			}
 
 			public Mono<String> slow() {
 				return WebClient.builder().baseUrl("http://localhost:" + port).build()
 						.get().uri("/slow").retrieve().bodyToMono(String.class)
-						.transform(it -> cbFactory.create("slow").run(it, t -> {
+						.transform(it -> cbFactory.createReactor("slow").run(it, t -> {
 							t.printStackTrace();
 							return Mono.just("fallback");
 						}));
@@ -131,7 +131,7 @@ public class ReactiveHystrixCircuitBreakerIntegrationTest {
 			public Mono<String> normal() {
 				return WebClient.builder().baseUrl("http://localhost:" + port).build()
 						.get().uri("/normal").retrieve().bodyToMono(String.class)
-						.transform(it -> cbFactory.create("normal").run(it, t -> {
+						.transform(it -> cbFactory.createReactor("normal").run(it, t -> {
 							t.printStackTrace();
 							return Mono.just("fallback");
 						}));

--- a/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/ReactorHystrixCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-hystrix/src/test/java/org/springframework/cloud/circuitbreaker/hystrix/ReactorHystrixCircuitBreakerTest.java
@@ -21,19 +21,19 @@ import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Ryan Baxter
  */
-public class ReactiveHystrixCircuitBreakerTest {
+public class ReactorHystrixCircuitBreakerTest {
 
 	@Test
 	public void monoRun() {
-		ReactiveCircuitBreaker cb = new ReactiveHystrixCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorHystrixCircuitBreakerFactory()
+				.createReactor("foo");
 		Mono<String> s = Mono.just("foobar")
 				.transform(it -> cb.run(it, t -> Mono.just("fallback")));
 		assertThat(s.block()).isEqualTo("foobar");
@@ -41,8 +41,8 @@ public class ReactiveHystrixCircuitBreakerTest {
 
 	@Test
 	public void monoFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveHystrixCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorHystrixCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Mono.error(new RuntimeException("boom"))
 				.transform(it -> cb.run(it, t -> Mono.just("fallback"))).block())
 						.isEqualTo("fallback");
@@ -50,8 +50,8 @@ public class ReactiveHystrixCircuitBreakerTest {
 
 	@Test
 	public void fluxRun() {
-		ReactiveCircuitBreaker cb = new ReactiveHystrixCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorHystrixCircuitBreakerFactory()
+				.createReactor("foo");
 		Flux<String> s = Flux.just("foobar", "hello world")
 				.transform(it -> cb.run(it, t -> Flux.just("fallback")));
 		assertThat(s.collectList().block())
@@ -60,8 +60,8 @@ public class ReactiveHystrixCircuitBreakerTest {
 
 	@Test
 	public void fluxFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveHystrixCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorHystrixCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Flux.error(new RuntimeException("boom"))
 				.transform(it -> cb.run(it, t -> Flux.just("fallback"))).collectList()
 				.block()).isEqualTo(Arrays.asList(new String[] { "fallback" }));

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactiveResilience4JAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.circuitbreaker.commons.Customizer;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,9 +38,9 @@ import org.springframework.context.annotation.Configuration;
 public class ReactiveResilience4JAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
-	public ReactiveCircuitBreakerFactory reactiveResilience4JCircuitBreakerFactory() {
-		return new ReactiveResilience4JCircuitBreakerFactory();
+	@ConditionalOnMissingBean(ReactorCircuitBreakerFactory.class)
+	public ReactorCircuitBreakerFactory reactiveResilience4JCircuitBreakerFactory() {
+		return new ReactorResilience4JCircuitBreakerFactory();
 	}
 
 	@Configuration
@@ -49,10 +49,10 @@ public class ReactiveResilience4JAutoConfiguration {
 	public static class ReactiveResilience4JCustomizerConfiguration {
 
 		@Autowired(required = false)
-		private List<Customizer<ReactiveResilience4JCircuitBreakerFactory>> customizers = new ArrayList<>();
+		private List<Customizer<ReactorResilience4JCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired(required = false)
-		private ReactiveResilience4JCircuitBreakerFactory factory;
+		private ReactorResilience4JCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactorResilience4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactorResilience4JCircuitBreakerFactory.java
@@ -28,14 +28,15 @@ import io.github.resilience4j.timelimiter.TimeLimiterConfig;
 
 import org.springframework.cloud.circuitbreaker.commons.Customizer;
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.util.Assert;
 
 /**
  * @author Ryan Baxter
  */
-public class ReactiveResilience4JCircuitBreakerFactory extends
-		ReactiveCircuitBreakerFactory<Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration, Resilience4JConfigBuilder> {
+public class ReactorResilience4JCircuitBreakerFactory extends
+		ReactorCircuitBreakerFactory<Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration, Resilience4JConfigBuilder> {
 
 	private Function<String, Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration> defaultConfiguration = id -> new Resilience4JConfigBuilder(
 			id).circuitBreakerConfig(CircuitBreakerConfig.ofDefaults())
@@ -47,11 +48,20 @@ public class ReactiveResilience4JCircuitBreakerFactory extends
 	private Map<String, Customizer<CircuitBreaker>> circuitBreakerCustomizers = new HashMap<>();
 
 	@Override
-	public ReactiveCircuitBreaker create(String id) {
+	public ReactorCircuitBreaker createReactor(String id) {
+		return create(id);
+	}
+
+	@Override
+	public ReactiveCircuitBreaker createReactive(String id) {
+		return create(id);
+	}
+
+	private ReactorResilience4JCircuitBreaker create(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration config = getConfigurations()
 				.computeIfAbsent(id, defaultConfiguration);
-		return new ReactiveResilience4JCircuitBreaker(id, config, circuitBreakerRegistry,
+		return new ReactorResilience4JCircuitBreaker(id, config, circuitBreakerRegistry,
 				Optional.ofNullable(circuitBreakerCustomizers.get(id)));
 	}
 

--- a/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/main/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerFactory.java
@@ -69,7 +69,7 @@ public class Resilience4JCircuitBreakerFactory extends
 	}
 
 	@Override
-	public Resilience4JCircuitBreaker create(String id) {
+	public Resilience4JCircuitBreaker createReactor(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		Resilience4JConfigBuilder.Resilience4JCircuitBreakerConfiguration config = getConfigurations()
 				.computeIfAbsent(id, defaultConfiguration);

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactorResilience4JCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/ReactorResilience4JCircuitBreakerTest.java
@@ -23,26 +23,27 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Ryan Baxter
  */
-public class ReactiveResilience4JCircuitBreakerTest {
+public class ReactorResilience4JCircuitBreakerTest {
 
 	@Test
 	public void runMono() {
-		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorResilience4JCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Mono.just("foobar").transform(it -> cb.run(it)).block())
 				.isEqualTo("foobar");
 	}
 
 	@Test
 	public void runMonoWithFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorResilience4JCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Mono.error(new RuntimeException("boom"))
 				.transform(it -> cb.run(it, t -> Mono.just("fallback"))).block())
 						.isEqualTo("fallback");
@@ -50,16 +51,33 @@ public class ReactiveResilience4JCircuitBreakerTest {
 
 	@Test
 	public void runFlux() {
-		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorResilience4JCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Flux.just("foobar", "hello world").transform(it -> cb.run(it))
 				.collectList().block()).isEqualTo(Arrays.asList("foobar", "hello world"));
 	}
 
 	@Test
 	public void runFluxWithFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveResilience4JCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorResilience4JCircuitBreakerFactory()
+				.createReactor("foo");
+		assertThat(Flux.error(new RuntimeException("boom"))
+				.transform(it -> cb.run(it, t -> Flux.just("fallback"))).collectList()
+				.block()).isEqualTo(Arrays.asList("fallback"));
+	}
+
+	@Test
+	public void runPublisher() {
+		ReactiveCircuitBreaker cb = new ReactorResilience4JCircuitBreakerFactory()
+				.createReactive("foo");
+		assertThat(Flux.just("foobar", "hello world").transform(it -> cb.run(it))
+				.collectList().block()).isEqualTo(Arrays.asList("foobar", "hello world"));
+	}
+
+	@Test
+	public void runPublisherWithFallback() {
+		ReactiveCircuitBreaker cb = new ReactorResilience4JCircuitBreakerFactory()
+				.createReactive("foo");
 		assertThat(Flux.error(new RuntimeException("boom"))
 				.transform(it -> cb.run(it, t -> Flux.just("fallback"))).collectList()
 				.block()).isEqualTo(Arrays.asList("fallback"));

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerIntegrationTest.java
@@ -164,18 +164,18 @@ public class Resilience4JCircuitBreakerIntegrationTest {
 			}
 
 			public String slow() {
-				return cbFactory.create("slow").run(
+				return cbFactory.createReactor("slow").run(
 						() -> rest.getForObject("/slow", String.class), t -> "fallback");
 			}
 
 			public String normal() {
-				return cbFactory.create("normal").run(
+				return cbFactory.createReactor("normal").run(
 						() -> rest.getForObject("/normal", String.class),
 						t -> "fallback");
 			}
 
 			public String slowOnDemand(int delayInMilliseconds) {
-				return cbFactory.create("slow")
+				return cbFactory.createReactor("slow")
 						.run(() -> rest
 								.exchange("/slowOnDemand", HttpMethod.GET,
 										createEntityWithOptionalDelayHeader(

--- a/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-resilience4j/src/test/java/org/springframework/cloud/circuitbreaker/resilience4j/Resilience4JCircuitBreakerTest.java
@@ -29,13 +29,13 @@ public class Resilience4JCircuitBreakerTest {
 
 	@Test
 	public void run() {
-		CircuitBreaker cb = new Resilience4JCircuitBreakerFactory().create("foo");
+		CircuitBreaker cb = new Resilience4JCircuitBreakerFactory().createReactor("foo");
 		assertThat(cb.run(() -> "foobar")).isEqualTo("foobar");
 	}
 
 	@Test
 	public void runWithFallback() {
-		CircuitBreaker cb = new Resilience4JCircuitBreakerFactory().create("foo");
+		CircuitBreaker cb = new Resilience4JCircuitBreakerFactory().createReactor("foo");
 		assertThat((String) cb.run(() -> {
 			throw new RuntimeException("boom");
 		}, t -> "fallback")).isEqualTo("fallback");

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerAutoConfiguration.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactiveSentinelCircuitBreakerAutoConfiguration.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.circuitbreaker.commons.Customizer;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,10 +38,10 @@ import org.springframework.context.annotation.Configuration;
 public class ReactiveSentinelCircuitBreakerAutoConfiguration {
 
 	@Bean
-	@ConditionalOnMissingBean(ReactiveCircuitBreakerFactory.class)
+	@ConditionalOnMissingBean(ReactorCircuitBreakerFactory.class)
 
-	public ReactiveCircuitBreakerFactory reactiveSentinelCircuitBreakerFactory() {
-		return new ReactiveSentinelCircuitBreakerFactory();
+	public ReactorCircuitBreakerFactory reactiveSentinelCircuitBreakerFactory() {
+		return new ReactorSentinelCircuitBreakerFactory();
 	}
 
 	@Configuration
@@ -50,10 +50,10 @@ public class ReactiveSentinelCircuitBreakerAutoConfiguration {
 	public static class ReactiveSentinelCustomizerConfiguration {
 
 		@Autowired(required = false)
-		private List<Customizer<ReactiveSentinelCircuitBreakerFactory>> customizers = new ArrayList<>();
+		private List<Customizer<ReactorSentinelCircuitBreakerFactory>> customizers = new ArrayList<>();
 
 		@Autowired(required = false)
-		private ReactiveSentinelCircuitBreakerFactory factory;
+		private ReactorSentinelCircuitBreakerFactory factory;
 
 		@PostConstruct
 		public void init() {

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactorSentinelCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/ReactorSentinelCircuitBreakerFactory.java
@@ -20,27 +20,37 @@ import java.util.ArrayList;
 import java.util.function.Function;
 
 import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreakerFactory;
 import org.springframework.cloud.circuitbreaker.sentinel.SentinelConfigBuilder.SentinelCircuitBreakerConfiguration;
 import org.springframework.util.Assert;
 
 /**
- * Factory for {@link ReactiveSentinelCircuitBreaker}.
+ * Factory for {@link ReactorSentinelCircuitBreaker}.
  *
  * @author Eric Zhao
  */
-public class ReactiveSentinelCircuitBreakerFactory extends
-		ReactiveCircuitBreakerFactory<SentinelConfigBuilder.SentinelCircuitBreakerConfiguration, SentinelConfigBuilder> {
+public class ReactorSentinelCircuitBreakerFactory extends
+		ReactorCircuitBreakerFactory<SentinelCircuitBreakerConfiguration, SentinelConfigBuilder> {
 
 	private Function<String, SentinelConfigBuilder.SentinelCircuitBreakerConfiguration> defaultConfiguration = id -> new SentinelConfigBuilder()
 			.resourceName(id).rules(new ArrayList<>()).build();
 
 	@Override
-	public ReactiveCircuitBreaker create(String id) {
+	public ReactorCircuitBreaker createReactor(String id) {
+		return create(id);
+	}
+
+	@Override
+	public ReactiveCircuitBreaker createReactive(String id) {
+		return create(id);
+	}
+
+	private ReactorSentinelCircuitBreaker create(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		SentinelConfigBuilder.SentinelCircuitBreakerConfiguration conf = getConfigurations()
 				.computeIfAbsent(id, defaultConfiguration);
-		return new ReactiveSentinelCircuitBreaker(id, conf.getEntryType(),
+		return new ReactorSentinelCircuitBreaker(id, conf.getEntryType(),
 				conf.getRules());
 	}
 

--- a/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/main/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerFactory.java
@@ -36,7 +36,7 @@ public class SentinelCircuitBreakerFactory extends
 			.resourceName(id).entryType(EntryType.OUT).rules(new ArrayList<>()).build();
 
 	@Override
-	public CircuitBreaker create(String id) {
+	public CircuitBreaker createReactor(String id) {
 		Assert.hasText(id, "A CircuitBreaker must have an id.");
 		SentinelConfigBuilder.SentinelCircuitBreakerConfiguration conf = getConfigurations()
 				.computeIfAbsent(id, defaultConfiguration);

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactorSentinelCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/ReactorSentinelCircuitBreakerTest.java
@@ -24,19 +24,19 @@ import org.junit.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import org.springframework.cloud.circuitbreaker.commons.ReactiveCircuitBreaker;
+import org.springframework.cloud.circuitbreaker.commons.ReactorCircuitBreaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Eric Zhao
  */
-public class ReactiveSentinelCircuitBreakerTest {
+public class ReactorSentinelCircuitBreakerTest {
 
 	@Test
 	public void testCreateWithNullRule() {
 		String id = "testCreateReactiveCbWithNullRule";
-		ReactiveSentinelCircuitBreaker cb = new ReactiveSentinelCircuitBreaker(id,
+		ReactorSentinelCircuitBreaker cb = new ReactorSentinelCircuitBreaker(id,
 				Collections.singletonList(null));
 		assertThat(Mono.just("foobar").transform(it -> cb.run(it)).block())
 				.isEqualTo("foobar");
@@ -45,16 +45,16 @@ public class ReactiveSentinelCircuitBreakerTest {
 
 	@Test
 	public void runMono() {
-		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorSentinelCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Mono.just("foobar").transform(it -> cb.run(it)).block())
 				.isEqualTo("foobar");
 	}
 
 	@Test
 	public void runMonoWithFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorSentinelCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Mono.error(new RuntimeException("boom"))
 				.transform(it -> cb.run(it, t -> Mono.just("fallback"))).block())
 						.isEqualTo("fallback");
@@ -62,16 +62,16 @@ public class ReactiveSentinelCircuitBreakerTest {
 
 	@Test
 	public void runFlux() {
-		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorSentinelCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Flux.just("foobar", "hello world").transform(it -> cb.run(it))
 				.collectList().block()).isEqualTo(Arrays.asList("foobar", "hello world"));
 	}
 
 	@Test
 	public void runFluxWithFallback() {
-		ReactiveCircuitBreaker cb = new ReactiveSentinelCircuitBreakerFactory()
-				.create("foo");
+		ReactorCircuitBreaker cb = new ReactorSentinelCircuitBreakerFactory()
+				.createReactor("foo");
 		assertThat(Flux.error(new RuntimeException("boom"))
 				.transform(it -> cb.run(it, t -> Flux.just("fallback"))).collectList()
 				.block()).isEqualTo(Arrays.asList("fallback"));

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerIntegrationTest.java
@@ -137,12 +137,12 @@ public class SentinelCircuitBreakerIntegrationTest {
 			}
 
 			public String slow() {
-				return cbFactory.create("slow").run(
+				return cbFactory.createReactor("slow").run(
 						() -> rest.getForObject("/slow", String.class), t -> "fallback");
 			}
 
 			public String normal() {
-				return cbFactory.create("normal").run(
+				return cbFactory.createReactor("normal").run(
 						() -> rest.getForObject("/normal", String.class),
 						t -> "fallback");
 			}

--- a/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-sentinel/src/test/java/org/springframework/cloud/circuitbreaker/sentinel/SentinelCircuitBreakerTest.java
@@ -69,14 +69,15 @@ public class SentinelCircuitBreakerTest {
 
 	@Test
 	public void testCreateFromFactoryThenRun() {
-		CircuitBreaker cb = new SentinelCircuitBreakerFactory().create("testSentinelRun");
+		CircuitBreaker cb = new SentinelCircuitBreakerFactory()
+				.createReactor("testSentinelRun");
 		assertThat(cb.run(() -> "foobar")).isEqualTo("foobar");
 	}
 
 	@Test
 	public void testRunWithFallback() {
 		CircuitBreaker cb = new SentinelCircuitBreakerFactory()
-				.create("testSentinelRunWithFallback");
+				.createReactor("testSentinelRunWithFallback");
 		assertThat(cb.<String>run(() -> {
 			throw new RuntimeException("boom");
 		}, t -> "fallback")).isEqualTo("fallback");

--- a/spring-cloud-circuitbreaker-spring-retry/src/main/java/org/springframework/cloud/circuitbreaker/springretry/SpringRetryCircuitBreakerFactory.java
+++ b/spring-cloud-circuitbreaker-spring-retry/src/main/java/org/springframework/cloud/circuitbreaker/springretry/SpringRetryCircuitBreakerFactory.java
@@ -50,7 +50,7 @@ public class SpringRetryCircuitBreakerFactory extends
 	}
 
 	@Override
-	public CircuitBreaker create(String id) {
+	public CircuitBreaker createReactor(String id) {
 		Assert.hasText(id, "A circuit breaker must have an id");
 		SpringRetryConfigBuilder.SpringRetryConfig config = getConfigurations()
 				.computeIfAbsent(id, defaultConfig);

--- a/spring-cloud-circuitbreaker-spring-retry/src/test/java/org/springframework/cloud/circuitbreaker/springretry/SpringRetryCircuitBreakerIntegrationTest.java
+++ b/spring-cloud-circuitbreaker-spring-retry/src/test/java/org/springframework/cloud/circuitbreaker/springretry/SpringRetryCircuitBreakerIntegrationTest.java
@@ -141,7 +141,7 @@ public class SpringRetryCircuitBreakerIntegrationTest {
 			}
 
 			public String slow() {
-				CircuitBreaker cb = cbFactory.create("slow");
+				CircuitBreaker cb = cbFactory.createReactor("slow");
 				for (int i = 0; i < 10; i++) {
 					cb.run(() -> rest.getForObject("/slow", String.class),
 							t -> "fallback");
@@ -151,7 +151,7 @@ public class SpringRetryCircuitBreakerIntegrationTest {
 			}
 
 			public String normal() {
-				return cbFactory.create("normal").run(
+				return cbFactory.createReactor("normal").run(
 						() -> rest.getForObject("/normal", String.class),
 						t -> "fallback");
 			}

--- a/spring-cloud-circuitbreaker-spring-retry/src/test/java/org/springframework/cloud/circuitbreaker/springretry/SpringRetryCircuitBreakerTest.java
+++ b/spring-cloud-circuitbreaker-spring-retry/src/test/java/org/springframework/cloud/circuitbreaker/springretry/SpringRetryCircuitBreakerTest.java
@@ -33,8 +33,8 @@ import static org.mockito.Mockito.verify;
 public class SpringRetryCircuitBreakerTest {
 
 	@Test
-	public void testCreate() {
-		CircuitBreaker cb = new SpringRetryCircuitBreakerFactory().create("foo");
+	public void testcreateReactor() {
+		CircuitBreaker cb = new SpringRetryCircuitBreakerFactory().createReactor("foo");
 		assertThat(cb.run(() -> "foo")).isEqualTo("foo");
 	}
 
@@ -47,7 +47,7 @@ public class SpringRetryCircuitBreakerTest {
 				throw new RuntimeException("boom");
 			}
 		});
-		CircuitBreaker cb = factory.create("foo");
+		CircuitBreaker cb = factory.createReactor("foo");
 		for (int i = 0; i < 10; i++) {
 			cb.run(spyedSup, t -> "fallback");
 		}


### PR DESCRIPTION
There is a new interface called `ReactorCircuitBreaker` which contains the Rector specific APIs.  `ReactiveCircuitBreaker` now just uses `Publisher`. The `Reactor*` implementations in circuit breaker implementations implement both interfaces. Since there are now two types of "Reactive" interfaces the `*Factory` classes now have a `createReactive` and `createReactor` methods.

What I would like some feedback on besides the above are the implementations of the `run` methods that deal with `Publisher`s.
https://github.com/spring-cloud-incubator/spring-cloud-circuitbreaker/pull/37/files#diff-89fc84ff8567e7656237a73a52e4e7f9R103